### PR TITLE
Video loading attempt

### DIFF
--- a/ChronoViz.xcodeproj/project.pbxproj
+++ b/ChronoViz.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		A943B9CE249E569900E5E618 /* MainVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = A943B9CD249E569900E5E618 /* MainVideo.m */; };
 		BB0159300EACE34300B41B99 /* AppController.m in Sources */ = {isa = PBXBuildFile; fileRef = BB01592F0EACE34300B41B99 /* AppController.m */; };
 		BB0159470EACE4BC00B41B99 /* play.png in Resources */ = {isa = PBXBuildFile; fileRef = BB0159450EACE4BC00B41B99 /* play.png */; };
 		BB0159480EACE4BC00B41B99 /* pause.png in Resources */ = {isa = PBXBuildFile; fileRef = BB0159460EACE4BC00B41B99 /* pause.png */; };
@@ -336,6 +337,8 @@
 		32CA4F630368D1EE00C91783 /* ChronoViz_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChronoViz_Prefix.pch; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* ChronoViz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChronoViz.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A943B9CD249E569900E5E618 /* MainVideo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainVideo.m; sourceTree = "<group>"; };
+		A943B9CF249E56A300E5E618 /* MainVideo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainVideo.h; sourceTree = "<group>"; };
 		BB01592E0EACE34300B41B99 /* AppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppController.h; sourceTree = "<group>"; };
 		BB01592F0EACE34300B41B99 /* AppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppController.m; sourceTree = "<group>"; };
 		BB0159450EACE4BC00B41B99 /* play.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = play.png; sourceTree = "<group>"; };
@@ -1104,6 +1107,8 @@
 				BB8456380F15417F004F187E /* SegmentBoundary.h */,
 				BB8456390F15417F004F187E /* SegmentBoundary.m */,
 				BBC57EE90FF566A7001C8E9F /* VideoProperties.h */,
+				A943B9CD249E569900E5E618 /* MainVideo.m */,
+				A943B9CF249E56A300E5E618 /* MainVideo.h */,
 				BBC57EEA0FF566A7001C8E9F /* VideoProperties.m */,
 			);
 			path = Core;
@@ -1688,6 +1693,7 @@
 				BBCE785910961FA10061BFD4 /* DataSource.m in Sources */,
 				BBFD986F109B50120099758A /* AnnotationTableView.m in Sources */,
 				BB35A05E109BA896002A0707 /* MapAnnotationLayer.m in Sources */,
+				A943B9CE249E569900E5E618 /* MainVideo.m in Sources */,
 				BBF5D7F110A09D4A00DDBEDE /* SenseCamDataSource.m in Sources */,
 				BB2F945510A2354F001550A6 /* TimeCodedString.m in Sources */,
 				BB08C20910A33C8300F188AD /* ImageSequenceView.m in Sources */,

--- a/ChronoViz.xcodeproj/project.pbxproj
+++ b/ChronoViz.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		A943B9CE249E569900E5E618 /* MainVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = A943B9CD249E569900E5E618 /* MainVideo.m */; };
+		A943B9D1249E5D2D00E5E618 /* MainVideoLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = A943B9D0249E5D2D00E5E618 /* MainVideoLoader.m */; };
 		BB0159300EACE34300B41B99 /* AppController.m in Sources */ = {isa = PBXBuildFile; fileRef = BB01592F0EACE34300B41B99 /* AppController.m */; };
 		BB0159470EACE4BC00B41B99 /* play.png in Resources */ = {isa = PBXBuildFile; fileRef = BB0159450EACE4BC00B41B99 /* play.png */; };
 		BB0159480EACE4BC00B41B99 /* pause.png in Resources */ = {isa = PBXBuildFile; fileRef = BB0159460EACE4BC00B41B99 /* pause.png */; };
@@ -339,6 +340,8 @@
 		8D1107320486CEB800E47090 /* ChronoViz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChronoViz.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A943B9CD249E569900E5E618 /* MainVideo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainVideo.m; sourceTree = "<group>"; };
 		A943B9CF249E56A300E5E618 /* MainVideo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainVideo.h; sourceTree = "<group>"; };
+		A943B9D0249E5D2D00E5E618 /* MainVideoLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainVideoLoader.m; sourceTree = "<group>"; };
+		A943B9D2249E5D3600E5E618 /* MainVideoLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainVideoLoader.h; sourceTree = "<group>"; };
 		BB01592E0EACE34300B41B99 /* AppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppController.h; sourceTree = "<group>"; };
 		BB01592F0EACE34300B41B99 /* AppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppController.m; sourceTree = "<group>"; };
 		BB0159450EACE4BC00B41B99 /* play.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = play.png; sourceTree = "<group>"; };
@@ -1107,6 +1110,8 @@
 				BB8456380F15417F004F187E /* SegmentBoundary.h */,
 				BB8456390F15417F004F187E /* SegmentBoundary.m */,
 				BBC57EE90FF566A7001C8E9F /* VideoProperties.h */,
+				A943B9D0249E5D2D00E5E618 /* MainVideoLoader.m */,
+				A943B9D2249E5D3600E5E618 /* MainVideoLoader.h */,
 				A943B9CD249E569900E5E618 /* MainVideo.m */,
 				A943B9CF249E56A300E5E618 /* MainVideo.h */,
 				BBC57EEA0FF566A7001C8E9F /* VideoProperties.m */,
@@ -1740,6 +1745,7 @@
 				BBFE228C11A9D7DC00D4C96D /* AnnotationSearchFilter.m in Sources */,
 				BBD2408D11C291DC001CDE54 /* TiledPDFDelegate.m in Sources */,
 				BBD240B911C2E7B5001CDE54 /* NSString+URIQuery.m in Sources */,
+				A943B9D1249E5D2D00E5E618 /* MainVideoLoader.m in Sources */,
 				BB49DD1611CABAEA00F9C601 /* DPViewManager.m in Sources */,
 				BB606D1A11CC0E7400E037BC /* TiledImage.m in Sources */,
 				BB342EDF11D277E500893573 /* DPConsoleWindowController.m in Sources */,

--- a/Classes/Core/AppController.m
+++ b/Classes/Core/AppController.m
@@ -3238,14 +3238,25 @@ static AppController *currentApp = nil;
 
 - (IBAction)stepOneFrameForward:(id)sender
 {
-	[mMovie stepForward];
-	[self moveToTime:[mMovie currentTime] fromSender:sender];
+    AVAsset *asset = [[mMovie currentItem] asset];
+    float framerate = [[[asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0] nominalFrameRate];
+    CMTime oneFrame = CMTimeMake(1, framerate);
+    CMTime newTime = CMTimeAdd([mMovie currentTime], oneFrame);
+    // [[mMovie currentItem] stepByCount:1];
+    // TODO: Why does stepByCount not work?
+	[self moveToTime:newTime fromSender:sender];
 }
 
 - (IBAction)stepOneFrameBackward:(id)sender
 {
-	[mMovie stepBackward];
-	[self moveToTime:[mMovie currentTime] fromSender:sender];
+    AVAsset *asset = [[mMovie currentItem] asset];
+    float framerate = [[[asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0] nominalFrameRate];
+    CMTime oneFrame = CMTimeMake(1, framerate);
+    CMTime newTime = CMTimeSubtract([mMovie currentTime], oneFrame);
+    // [[mMovie currentItem] stepByCount:-1];
+    // TODO: Why does stepByCount not work?
+	[self moveToTime:newTime fromSender:sender];
+    // TODO: Why does moveToTime not move to the time when actual video is loaded?
 }
 
 - (IBAction)fastForward:(id)sender

--- a/Classes/Core/MainVideo.h
+++ b/Classes/Core/MainVideo.h
@@ -1,0 +1,24 @@
+//
+//  Video.h
+//  ChronoViz
+//
+//  Created by Johannes Maas on 20.06.20.
+//
+
+#import <AVKit/AVKit.h>
+
+@interface MainVideo : NSObject {
+    AVPlayer *_player;
+}
+
+@property(nonatomic, readonly) CMTime currentTime;
+
+@property(readonly) CMTime duration;
+@property(readonly) CGSize dimensions;
+
+/**
+ Expects a specially configured and ready AVPlayer. Use a MainVideoLoader instead of calling this directly.
+ */
+- (id)initWithReadyPlayer:(AVPlayer *)player;
+
+@end

--- a/Classes/Core/MainVideo.m
+++ b/Classes/Core/MainVideo.m
@@ -1,0 +1,33 @@
+//
+//  Video.m
+//  ChronoViz
+//
+//  Created by Johannes Maas on 20.06.20.
+//
+
+#import "MainVideo.h"
+
+@implementation MainVideo
+
+@synthesize currentTime;
+@synthesize duration;
+@synthesize dimensions;
+
+- (id)initWitReadyPlayer:(AVPlayer *)player {
+    self = [super init];
+    
+    if (self) {
+        _player = player;
+        
+        duration = _player.currentItem.duration;
+        dimensions = [[[_player.currentItem.asset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0] naturalSize];
+    }
+    
+    return self;
+}
+
+- (CMTime)currentTime {
+    return _player.currentTime;
+}
+
+@end

--- a/Classes/Core/MainVideoLoader.h
+++ b/Classes/Core/MainVideoLoader.h
@@ -1,0 +1,21 @@
+//
+//  MainVideoLoader.h
+//  ChronoViz
+//
+//  Created by Johannes Maas on 20.06.20.
+//
+
+#import "MainVideo.h"
+
+#import <AVKit/AVKit.h>
+
+typedef void (^LoadedCallbackBlock)(MainVideo *);
+
+@interface MainVideoLoader : NSObject
+
+@property (retain) AVPlayerItem *playerItem;
+@property (copy) LoadedCallbackBlock callbackBlock;
+
+- (void)loadFromFile:(NSString *)fileName whenLoaded:(LoadedCallbackBlock)callbackBlock;
+
+@end

--- a/Classes/Core/MainVideoLoader.m
+++ b/Classes/Core/MainVideoLoader.m
@@ -1,0 +1,66 @@
+//
+//  MainVideoLoader.m
+//  ChronoViz
+//
+//  Created by Johannes Maas on 20.06.20.
+//
+
+#import "MainVideoLoader.h"
+
+@implementation MainVideoLoader
+
+// Marker for value observing callback.
+static const NSString *PlayerItemContext;
+
+@synthesize playerItem;
+@synthesize callbackBlock;
+
+- (void)loadFromFile:(NSURL *)url whenLoaded:(LoadedCallbackBlock)callbackBlock {
+    AVAsset *asset = [AVAsset assetWithURL:url];
+    NSArray<NSString *> *assetKeysToLoad = @[@"duration", @"tracks"];
+    self.playerItem = [AVPlayerItem playerItemWithAsset:asset automaticallyLoadedAssetKeys:assetKeysToLoad];
+        
+    NSKeyValueObservingOptions options = NSKeyValueObservingOptionNew;
+    [self.playerItem addObserver:self forKeyPath:@"status"
+                         options:options context:&PlayerItemContext];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSString *,id> *)change
+                       context:(void *)context {
+    // Only handle observations for the PlayerItemContext
+    if (context != &PlayerItemContext) {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+        return;
+    }
+ 
+    if ([keyPath isEqualToString:@"status"]) {
+        AVPlayerItemStatus status = AVPlayerItemStatusUnknown;
+        // Get the status change from the change dictionary
+        NSNumber *statusNumber = change[NSKeyValueChangeNewKey];
+        if ([statusNumber isKindOfClass:[NSNumber class]]) {
+            status = statusNumber.integerValue;
+        }
+        // Switch over the status
+        switch (status) {
+            case AVPlayerItemStatusReadyToPlay: {
+                AVPlayer *player = [AVPlayer playerWithPlayerItem:self.playerItem];
+                MainVideo *mainVideo = [[MainVideo alloc] initWithReadyPlayer:player];
+                callbackBlock(mainVideo);
+                break;
+            }
+            case AVPlayerItemStatusFailed:
+                // Failed. Examine AVPlayerItem.error
+                NSLog(@"Loading video failed.");
+                // TODO: Pass error to callback.
+                break;
+            case AVPlayerItemStatusUnknown:
+                // Not ready
+                NSAssert(false, @"This case should never happen.");
+                break;
+        }
+    }
+}
+
+@end


### PR DESCRIPTION
Dealing with the asynchronous loading is absolutely horrible with the language and the APIs. I don't think this branch is a reasonable approach.

My idea was to have a `MainVideo` object that can only be created with an `AVPlayer` that's ready and that will automatically get and cache all relevant information like `duration`. However, the split into a loader and a data object does not appear to work well, so I'll very probably abandon this approach.