### PR TITLE
Category playback

### DIFF
--- a/Classes/Core/AppController.h
+++ b/Classes/Core/AppController.h
@@ -330,5 +330,6 @@
 
 - (IBAction)goFullScreen:(id)sender; // toggle full screen
 - (IBAction)exitFullScreen:(id)sender;
+@property (assign) IBOutlet NSPopUpButton *selectedCategoryPopupButton;
 
 @end

--- a/Classes/Core/AppController.h
+++ b/Classes/Core/AppController.h
@@ -193,6 +193,8 @@
 @property float playbackRate;
 @property float newDocumentDuration;
 @property int currentTool;
+@property (assign) IBOutlet NSPopUpButton *selectedCategoryPopupButton;
+@property(retain) id boundaryListener;
 
 + (AppController*)currentApp;
 + (AnnotationDocument*)currentDoc;
@@ -330,6 +332,5 @@
 
 - (IBAction)goFullScreen:(id)sender; // toggle full screen
 - (IBAction)exitFullScreen:(id)sender;
-@property (assign) IBOutlet NSPopUpButton *selectedCategoryPopupButton;
 
 @end

--- a/Classes/Core/AppController.m
+++ b/Classes/Core/AppController.m
@@ -787,7 +787,8 @@ static AppController *currentApp = nil;
     {
         NSString *selectedCategoryName = [self.selectedCategoryPopupButton titleOfSelectedItem];
         AnnotationCategory *selectedCategory = [self.document categoryForName:selectedCategoryName];
-        NSLog(@"%@", selectedCategory);
+        
+        NSLog(@"Playback limited to category %@", selectedCategory.name);
         
         NSMutableArray *startTimes = [NSMutableArray array];
         NSMutableArray *endTimes = [NSMutableArray array];
@@ -830,7 +831,8 @@ static AppController *currentApp = nil;
                        {
                            if (loopPlayback)
                            {
-                               [self moveToTime:[[startTimes firstObject] CMTimeValue] fromSender:nil];
+                               CMTime firstStartTime = [[startTimes firstObject] CMTimeValue];
+                               [self moveToTime:firstStartTime fromSender:nil];
                            }
                            else
                            {

--- a/Classes/Core/AppController.m
+++ b/Classes/Core/AppController.m
@@ -685,7 +685,8 @@ static AppController *currentApp = nil;
 	[self willChangeValueForKey:@"document"];
 	
 	[doc retain];
-	
+    
+    
 	if(annotationDoc)
 	{
 		[self closeDocument];
@@ -765,7 +766,31 @@ static AppController *currentApp = nil;
     [[AppController currentApp] endDocumentLoading:self];
     
 	[self didChangeValueForKey:@"document"];
+    
+    // Populate category playback selector.
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(updateCategorySelection)
+                                                 name:DPCategoryChangeNotification
+                                               object:nil];
+    [self updateCategorySelection];
 }
+
+- (IBAction)newCategorySelected:(id)sender {
+    NSLog(@"%ld", (long)[self.selectedCategoryPopupButton indexOfSelectedItem]);
+}
+
+- (void)updateCategorySelection{
+    [self.selectedCategoryPopupButton removeAllItems];
+    
+    NSMutableArray<NSString*> *categoryNames = [[NSMutableArray alloc] init];
+    for (AnnotationCategory *category in self.document.categories) {
+        [categoryNames addObject:category.name];
+    }
+    [self.selectedCategoryPopupButton addItemsWithTitles:categoryNames];
+    // TODO: Release `categoryNames`?
+}
+
+
 
 - (void)setMainVideo:(VideoProperties *)video;
 {

--- a/Resources/English.lproj/MainMenu.xib
+++ b/Resources/English.lproj/MainMenu.xib
@@ -641,6 +641,24 @@ DQ
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IhV-Kf-uSF">
+                        <rect key="frame" x="523" y="39" width="100" height="25"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="0EO-d7-veU" id="DpD-SV-22c">
+                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <menu key="menu" id="X5i-3m-vSa">
+                                <items>
+                                    <menuItem title="Item 1" state="on" id="0EO-d7-veU"/>
+                                    <menuItem title="Item 2" id="mcD-92-OhX"/>
+                                    <menuItem title="Item 3" id="JLE-bv-8Fn"/>
+                                </items>
+                            </menu>
+                        </popUpButtonCell>
+                        <connections>
+                            <action selector="newCategorySelected:" target="375" id="I4W-WY-bK6"/>
+                        </connections>
+                    </popUpButton>
                 </subviews>
                 <connections>
                     <outlet property="mAppController" destination="375" id="445"/>
@@ -794,6 +812,7 @@ DQ
                 <outlet property="saveAsView" destination="835" id="844"/>
                 <outlet property="saveFileTypesButton" destination="836" id="845"/>
                 <outlet property="savedStatesMenu" destination="1466" id="1470"/>
+                <outlet property="selectedCategoryPopupButton" destination="IhV-Kf-uSF" id="WUu-ws-IRH"/>
                 <outlet property="splitView" destination="1017" id="1033"/>
                 <outlet property="timelineSelectionPanel" destination="1389" id="1422"/>
                 <outlet property="timelineSelectionView" destination="1412" id="1423"/>
@@ -1168,7 +1187,7 @@ DQ
             <connections>
                 <outlet property="delegate" destination="757" id="945"/>
             </connections>
-            <point key="canvasLocation" x="140" y="347"/>
+            <point key="canvasLocation" x="-324" y="427"/>
         </window>
         <customObject id="757" customClass="AnnotationInspector">
             <connections>
@@ -1658,7 +1677,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" ambiguous="YES" id="7J9-Gl-bO4">
                             <rect key="frame" x="1" y="1" width="308" height="243"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <outlineView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1323" id="1321">
                                     <rect key="frame" x="0.0" y="0.0" width="308" height="243"/>
@@ -1744,6 +1763,7 @@ Gw
                     </button>
                 </subviews>
             </view>
+            <point key="canvasLocation" x="140" y="449"/>
         </window>
         <window title="TimelineSelector" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="1389" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
@@ -1759,7 +1779,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                         <clipView key="contentView" ambiguous="YES" id="aQf-Hu-DnK">
                             <rect key="frame" x="1" y="0.0" width="308" height="281"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <outlineView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="20" headerView="1413" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1414" id="1412">
                                     <rect key="frame" x="0.0" y="0.0" width="308" height="258"/>
@@ -1770,6 +1790,7 @@ Gw
                                     <tableColumns>
                                         <tableColumn width="305" minWidth="16" maxWidth="1000" id="1414">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>
@@ -1822,6 +1843,7 @@ Gw
                     </button>
                 </subviews>
             </view>
+            <point key="canvasLocation" x="140" y="461"/>
         </window>
         <customObject id="1443" customClass="SUUpdater"/>
     </objects>

--- a/Resources/English.lproj/MainMenu.xib
+++ b/Resources/English.lproj/MainMenu.xib
@@ -423,14 +423,14 @@ DQ
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <box autoresizesSubviews="NO" fixedFrame="YES" borderType="none" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="1288">
-                        <rect key="frame" x="120" y="13" width="400" height="78"/>
+                        <rect key="frame" x="120" y="13" width="505" height="78"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <view key="contentView" id="3WC-7s-xO9">
-                            <rect key="frame" x="0.0" y="0.0" width="400" height="78"/>
+                            <rect key="frame" x="0.0" y="0.0" width="505" height="78"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1286">
-                                    <rect key="frame" x="308" y="15" width="68" height="14"/>
+                                    <rect key="frame" x="308" y="14" width="68" height="14"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Play Mode" id="1287">
                                         <font key="font" metaFont="message" size="11"/>
@@ -439,7 +439,7 @@ DQ
                                     </textFieldCell>
                                 </textField>
                                 <segmentedControl verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1280">
-                                    <rect key="frame" x="295" y="29" width="95" height="25"/>
+                                    <rect key="frame" x="295" y="26" width="95" height="25"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                     <segmentedCell key="cell" state="on" borderStyle="border" alignment="left" style="texturedRounded" trackingMode="selectAny" id="1281">
                                         <font key="font" metaFont="system"/>
@@ -452,6 +452,24 @@ DQ
                                         <action selector="playbackModeButtonClicked:" target="375" id="1289"/>
                                     </connections>
                                 </segmentedControl>
+                                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IhV-Kf-uSF">
+                                    <rect key="frame" x="396" y="25" width="112" height="25"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingMiddle" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="0EO-d7-veU" id="DpD-SV-22c">
+                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                        <font key="font" metaFont="menu"/>
+                                        <menu key="menu" id="X5i-3m-vSa">
+                                            <items>
+                                                <menuItem title="Item 1" state="on" id="0EO-d7-veU"/>
+                                                <menuItem title="Item 2" id="mcD-92-OhX"/>
+                                                <menuItem title="Item 3" id="JLE-bv-8Fn"/>
+                                            </items>
+                                        </menu>
+                                    </popUpButtonCell>
+                                    <connections>
+                                        <action selector="newCategorySelected:" target="375" id="I4W-WY-bK6"/>
+                                    </connections>
+                                </popUpButton>
                             </subviews>
                         </view>
                     </box>
@@ -641,24 +659,6 @@ DQ
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IhV-Kf-uSF">
-                        <rect key="frame" x="523" y="39" width="100" height="25"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="0EO-d7-veU" id="DpD-SV-22c">
-                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                            <menu key="menu" id="X5i-3m-vSa">
-                                <items>
-                                    <menuItem title="Item 1" state="on" id="0EO-d7-veU"/>
-                                    <menuItem title="Item 2" id="mcD-92-OhX"/>
-                                    <menuItem title="Item 3" id="JLE-bv-8Fn"/>
-                                </items>
-                            </menu>
-                        </popUpButtonCell>
-                        <connections>
-                            <action selector="newCategorySelected:" target="375" id="I4W-WY-bK6"/>
-                        </connections>
-                    </popUpButton>
                 </subviews>
                 <connections>
                     <outlet property="mAppController" destination="375" id="445"/>
@@ -1085,7 +1085,7 @@ DQ
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                         <clipView key="contentView" ambiguous="YES" id="xDO-Lc-mPZ">
                             <rect key="frame" x="1" y="1" width="283" height="57"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" id="1074">
                                     <rect key="frame" x="0.0" y="0.0" width="283" height="57"/>
@@ -1282,7 +1282,7 @@ DQ
                     <rect key="frame" x="20" y="208" width="303" height="1"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <view key="contentView" id="k9f-oe-MOJ">
-                        <rect key="frame" x="1" y="1" width="301" height="0.0"/>
+                        <rect key="frame" x="1" y="0.5" width="301" height="0.0"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     </view>
                     <color key="borderColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -1436,7 +1436,7 @@ Gw
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="JtB-4Q-x06">
                         <rect key="frame" x="1" y="0.0" width="243" height="251"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <outlineView focusRingType="none" verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" headerView="1238" indentationPerLevel="16" outlineTableColumn="1239" id="1237">
                                 <rect key="frame" x="0.0" y="0.0" width="243" height="228"/>
@@ -1510,7 +1510,7 @@ Gw
                     <autoresizingMask key="autoresizingMask"/>
                     <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="1kj-id-FJr">
                         <rect key="frame" x="1" y="1" width="258" height="43"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textView ambiguous="YES" drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" usesRuler="YES" spellingCorrection="YES" smartInsertDelete="YES" id="1251">
                                 <rect key="frame" x="0.0" y="0.0" width="258" height="43"/>
@@ -1677,7 +1677,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <clipView key="contentView" ambiguous="YES" id="7J9-Gl-bO4">
                             <rect key="frame" x="1" y="1" width="308" height="243"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <outlineView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1323" id="1321">
                                     <rect key="frame" x="0.0" y="0.0" width="308" height="243"/>
@@ -1779,7 +1779,7 @@ Gw
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                         <clipView key="contentView" ambiguous="YES" id="aQf-Hu-DnK">
                             <rect key="frame" x="1" y="0.0" width="308" height="281"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <outlineView verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="20" headerView="1413" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1414" id="1412">
                                     <rect key="frame" x="0.0" y="0.0" width="308" height="258"/>


### PR DESCRIPTION
Play back all annotations belonging to a category.

This is a proof of concept. A real implementation would be based around arbitrary annotation selections/sets. It could also reuse the category filters for timelines. It should also signal what parts it plays back prominently, e.g. by graying out all skipped parts of the timeline.

Since this feature is not fully-fledged, it will be kept on a separate branch, so that it can easily be dropped.